### PR TITLE
Skip requests to /om/hubspot/

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -77,6 +78,11 @@ func (w *wrapResponseWriter) WriteHeader(status int) {
 
 func wrapper(fn func(w http.ResponseWriter, r *http.Request)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/om/hubspot/") {
+			http.Error(w, r.URL.Path, http.StatusNotFound)
+			return
+		}
+
 		proc := time.Now()
 		writer := &wrapResponseWriter{
 			ResponseWriter: w,


### PR DESCRIPTION
As seen in the gcsproxy logs it would look like we are duplicating the calls to get artifacts:
- The first call is the correct one
- The second one is a typo'ed request (probably a misconfiguration/bug) 

```
2022/01/27 23:31:44 [127.0.0.1:43924] 0.038 200 GET /hubspot-maven-artifacts-prod/snapshots/com/hubspot/JanusClient/1.0-SNAPSHOT/maven-metadata.xml
2022/01/27 23:31:44 [127.0.0.1:43924] 0.013 404 GET /hubspot-maven-artifacts-prod/snapshots/om/hubspot/JanusClient/1.0-SNAPSHOT/maven-metadata.xml
2022/01/27 23:31:45 [127.0.0.1:43924] 0.031 200 GET /hubspot-maven-artifacts-prod/snapshots/com/hubspot/CosIndexModel/1.0-SNAPSHOT/maven-metadata.xml
2022/01/27 23:31:45 [127.0.0.1:43924] 0.012 404 GET /hubspot-maven-artifacts-prod/snapshots/om/hubspot/CosIndexModel/1.0-SNAPSHOT/maven-metadata.xml
```

This PR is to avoid making those calls while investigating where the misconfiguration/bug is. 

The PR was tested in the test cluster

@jhaber @kmclarnon @marcob 